### PR TITLE
Calling a group name now initiates or joins conference call

### DIFF
--- a/api/voice/voiceHandler.js
+++ b/api/voice/voiceHandler.js
@@ -1,24 +1,14 @@
 require("dotenv");
-const ClientCapability = require("twilio").jwt.ClientCapability;
 const VoiceResponse = require("twilio").twiml.VoiceResponse;
 const AccessToken = require("twilio").jwt.AccessToken;
 const accountSid = process.env.ACCOUNT_SID;
-const authToken = process.env.AUTH_TOKEN;
-const client = require("twilio")(accountSid, authToken);
 const VoiceGrant = AccessToken.VoiceGrant;
-const appSid = process.env.APP_SID;
 const apiKey = process.env.API_KEY;
 const apiKeySecret = process.env.API_KEY_SECRET;
 const pushCredSid = process.env.PUSH_CREDENTIAL_SID;
 const outgoingApplicationSid = process.env.APP_SID;
 const callerNumber = process.env.CALLER_ID;
-
-exports.generateNTSToken = function generateNTSToken() {
-  client.tokens
-    .create()
-    .then(token => console.log(token.username))
-    .catch(err => console.log("NTS Token err:", err));
-};
+const urlencoded = require('body-parser').urlencoded;
 
 exports.tokenGenerator = function tokenGenerator(req) {
   const defaultIdentity = Date.now();
@@ -62,65 +52,14 @@ exports.makeCall = function makeCall(request, response) {
   if (!to) {
       voiceResponse.say("Congratulations! You have made your first call! Good bye.");
   } else if (isNumber(to)) {
-      const dial = voiceResponse.dial.conference(`${request.body.groupName}`);
-      dial.number(to);
+      const dial = voiceResponse.dial({callerId : callerNumber});
+      dial.conference(to);
   } else {
       const dial = voiceResponse.dial({callerId : callerNumber});
-      dial.client(to);
+      dial.conference(to);
   }
   console.log('Response:' + voiceResponse.toString());
   return voiceResponse.toString();
-}
-
-exports.incoming = function incoming() {
-  const voiceResponse = new VoiceResponse();
-  voiceResponse.say("Congratulations! You have received your first inbound call! Good bye.");
-  console.log('res:' + voiceResponse.toString());
-  return voiceResponse.toString();
-}
-
-exports.placeCall = async function placeCall(req, res) {
-  // The recipient of the call, a phone number or a client
-  var to = null;
-    if (req.method == 'POST') {
-    to = await req.body.to;
-  } else {
-    to = await req.query.to;
-  }
-  console.log(to);
-  // The fully qualified URL that should be consulted by Twilio when the call connects.
-  var url = req.protocol + '://' + req.get('host') + '/incoming';
-  console.log(url);
-  const accountSid = process.env.ACCOUNT_SID;
-  const apiKey = process.env.API_KEY;
-  const apiSecret = process.env.API_KEY_SECRET;
-  const client = require('twilio')(apiKey, apiSecret, { accountSid: accountSid } );
-
-  if (!to) {
-    console.log("Calling default client:" + defaultIdentity);
-    call = await client.api.calls.create({
-      url: url,
-      to: 'client:' + defaultIdentity,
-      from: callerId,
-    });
-  } else if (isNumber(to)) {
-    console.log("Calling number:" + to);
-    call = await client.api.calls.create({
-      url: url,
-      to: to,
-      from: callerNumber,
-    });
-  } else {
-    console.log("Calling client:" + to);
-    call =  await client.api.calls.create({
-      url: url,
-      to: 'client:' + to,
-      from: callerId,
-    });
-  }
-  console.log(call.sid)
-  //call.then(console.log(call.sid));
-  return call.sid;
 }
 
 exports.voiceResponse = function voiceResponse(toNumber) {

--- a/api/voice/voiceRouter.js
+++ b/api/voice/voiceRouter.js
@@ -13,36 +13,12 @@ router.get('/accessToken', (req, res) => {
   res.send(voiceHandler.tokenGenerator(req));
 });
 
-router.get('/incoming', function(req, res) {
-  res.send(voiceHandler.incoming());
-});
-
-router.post('/incoming', function(req, res) {
-  res.send(voiceHandler.incoming());
-});
-
-router.get('/ntstoken', (req, res) => {
-  res.send(voiceHandler.generateNTSToken());
-});
-
 router.get('/makeCall', (req, res) => {
   res.send(voiceHandler.makeCall(req, res));
 });
 
 router.post('/makeCall', (req, res) => {
   res.send(voiceHandler.makeCall(req, res));
-});
-
-router.get('/placeCall', (req, res) => {
-  res.send(voiceHandler.placeCall(req, res));
-});
-
-router.post('/placeCall', (req, res) => {
-  res.send(voiceHandler.placeCall(req, res));
-});
-
-router.post('/', (req, res) => {
-  res.send(voiceHandler.voiceResponse(req.body.To));
 });
 
 module.exports = router;


### PR DESCRIPTION
# Description

Twilio now properly hosts a conference by group name and is able to host multiple concurrent conferences.
Trimmed unnecessary functions and routes from voiceHandler and voiceRouter respectively.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## Change status
- [x] Complete, but not tested (may need new tests)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
